### PR TITLE
log: type on 2nd args to trigger auto complete

### DIFF
--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -70,7 +70,7 @@ console.log($1)
 endsnippet
 
 snippet clv "console.log variable" w
-console.log('$1:', $1)
+console.log('$1:', ${1:})
 endsnippet
 
 snippet ce "console.error" w
@@ -78,7 +78,7 @@ console.error($1)
 endsnippet
 
 snippet cev "console.error variable" w
-console.error('$1: ', $1)
+console.error('$1: ', ${1:})
 endsnippet
 
 snippet cw "console.warn" w
@@ -86,7 +86,7 @@ console.warn($1)
 endsnippet
 
 snippet cwv "console.warn variable" w
-console.warn('$1: ', $1)
+console.warn('$1: ', ${1:})
 endsnippet
 
 snippet ct "console.table" w
@@ -98,7 +98,7 @@ console.debug($1)
 endsnippet
 
 snippet cdv "console.debug variable" w
-console.debug('$1: ', $1)
+console.debug('$1: ', ${1:})
 endsnippet
 
 snippet dev "process.env.NODE_ENV !== 'production'" w

--- a/UltiSnips/typescript.snippets
+++ b/UltiSnips/typescript.snippets
@@ -70,7 +70,7 @@ console.log($1)
 endsnippet
 
 snippet clv "console.log variable" w
-console.log("$1:", $1)
+console.log("$1:", ${1:})
 endsnippet
 
 snippet ce "console.error" w
@@ -78,7 +78,7 @@ console.error($1)
 endsnippet
 
 snippet cev "console.error variable" w
-console.error("$1: ", $1)
+console.error("$1: ", ${1:})
 endsnippet
 
 snippet cw "console.warn" w
@@ -86,7 +86,7 @@ console.warn($1)
 endsnippet
 
 snippet cwv "console.warn variable" w
-console.warn("$1: ", $1)
+console.warn("$1: ", ${1:})
 endsnippet
 
 snippet ct "console.table" w
@@ -98,7 +98,7 @@ console.debug($1)
 endsnippet
 
 snippet cdv "console.debug variable" w
-console.debug("$1: ", $1)
+console.debug("$1: ", ${1:})
 endsnippet
 
 snippet dev "process.env.NODE_ENV !== 'production'" w


### PR DESCRIPTION
Let the user type on the second variable on console logging. It improves a bit of the user experience which allows IDE to trigger a suggestion for the available variable on typing.