### PR TITLE
feat(useImperativeHandle)!: remove dependency tabstop and `{}` tabstop

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ const $REF = useRef$TABSTOP(TABSTOP)
 ```ts
 useImperativeHandle($REF, () => ({
   $TABSTOP,
-}), [$TABSTOP])
+}), [])
 ```
 
 #### useLayoutEffect
@@ -1046,7 +1046,7 @@ const $REF = useRef($TABSTOP)
 ```js
 useImperativeHandle($REF, () => ({
   $TABSTOP,
-}), [$TABSTOP])
+}), [])
 ```
 
 #### useLayoutEffect

--- a/UltiSnips/javascript.snippets
+++ b/UltiSnips/javascript.snippets
@@ -379,9 +379,9 @@ const ${1:ref} = useRef(${2:null})
 endsnippet
 
 snippet useI "useImperativeHandle(ref, createHandle, [inputs])" b
-useImperativeHandle(${1:ref}, ${4:() => ({
-	$2
-})}, ${5:[$3]})
+useImperativeHandle(${1:ref}, () => ({
+	$0
+}), [])
 endsnippet
 
 snippet useL "useLayoutEffect()" b

--- a/UltiSnips/typescript.snippets
+++ b/UltiSnips/typescript.snippets
@@ -496,9 +496,9 @@ const ${1:ref} = useRef$3(${2:null})$0
 endsnippet
 
 snippet useI "useImperativeHandle(ref, createHandle, [inputs])" b
-useImperativeHandle(${1:ref}, ${4:() => ({
-	$2
-})}, ${5:[$3]})
+useImperativeHandle(${1:ref}, () => ({
+	$0
+}), [])
 endsnippet
 
 snippet useL "useLayoutEffect()" b


### PR DESCRIPTION
I removed the dependency array from this snippet since I normally let
eslint autofill these instead of manually typing them.

I removed the "convenience" wrapper to replace the return block because
I never use it.